### PR TITLE
Add backend selector and map TinyViT operations to torch

### DIFF
--- a/scripts/tinyvit_mnist_pytorch.py
+++ b/scripts/tinyvit_mnist_pytorch.py
@@ -9,8 +9,6 @@ import sys
 sys.path.append('.')
 
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
 import torchvision
 from torch.utils.data import DataLoader, Subset
 from torchvision import transforms
@@ -105,7 +103,7 @@ def main() -> None:
             xb, yb = xb.to(DEVICE), yb.to(DEVICE)
             with backend.set_grad_enabled(train):
                 logits = model(xb)
-                loss = F.cross_entropy(logits, yb)
+                loss = backend.cross_entropy(logits, yb)
                 if train:
                     opt.zero_grad()
                     loss.backward()

--- a/src/backends/torch_backend.py
+++ b/src/backends/torch_backend.py
@@ -1,9 +1,14 @@
 import torch
+import torch.nn.functional as F
 
 # Tensor operations
 matmul = torch.matmul
 add = torch.add
 relu = torch.relu
+mean = torch.mean
+
+# Loss functions
+cross_entropy = F.cross_entropy
 
 # Other operations
 set_grad_enabled = torch.set_grad_enabled

--- a/src/model.py
+++ b/src/model.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 
 from src.core.tensor import Tensor
+from src.core.backend import backend
 
 # Model hyperparams
 PATCH = 4
@@ -31,7 +32,7 @@ class TinyViT(nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         x = self.patch_conv(x)
         x = x.flatten(2).transpose(1, 2)
-        x = x + self.pos_emb
+        x = backend.add(x, self.pos_emb)
         x = self.encoder(x)
-        x = x.mean(dim=1)
+        x = backend.mean(x, dim=1)
         return self.cls_head(x)


### PR DESCRIPTION
## Summary
- implement torch backend with basic ops and loss
- route TinyViT forward through backend add/mean
- use backend.cross_entropy in MNIST training script

## Testing
- `python scripts/tinyvit_mnist_pytorch.py`


------
https://chatgpt.com/codex/tasks/task_e_68a44049da50832eae9a60dcae800d00